### PR TITLE
Add cors package

### DIFF
--- a/lib/mini-mock-api.js
+++ b/lib/mini-mock-api.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var express = require('express');
+var cors = require('cors')
 var fs = require('fs');
 var path = require('path');
 var _ = require('lodash-node');
@@ -20,6 +21,7 @@ var MiniMockAPI = function(options){
   };
   this.options = _.extend(this.defaults, options);
   this.app = express();
+  this.app.use(cors());
   return this;
 };
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/pwambach/mini-mock-api",
   "dependencies": {
+    "cors": "^2.7.1",
     "express": "^4.12.4",
     "lodash-node": "^3.9.3",
     "q": "^1.4.1"


### PR DESCRIPTION
This should resolve #1 and give us CORS to allow web apps from different domains connect and consume the mini-mock-api.
